### PR TITLE
fix: update content security policy header

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,12 +28,14 @@ const nextConfig = {
           key: "Content-Security-Policy",
           value: `
           child-src 'none';
+          connect-src 'self' ws: https://fonts.gstatic.com/s/titilliumweb/v15/NaPecZTIAOhVxoMyOr9n_E7fRMc.woff;
           default-src 'self';
           frame-ancestors 'none';
-          img-src 'self' data:;
+          img-src 'self' data: https://i.imgur.com/jOjPBNg.jpg https://i.imgur.com/0UzB7N1.jpg https://i.imgur.com/Zadamhe.jpg https://i.imgur.com/7nVHtOd.png;
           media-src 'none';
-          script-src 'self' 'unsafe-eval' 'unsafe-inline';
+          script-src 'self' 'unsafe-eval' 'unsafe-inline' blob:;
           style-src 'self' 'unsafe-inline';
+          worker-src 'self' blob:;
         `
             .replace(/\s{2,}/g, " ")
             .trim(),

--- a/src/components/space/satellite.tsx
+++ b/src/components/space/satellite.tsx
@@ -1,9 +1,10 @@
 import { useRef, useState } from "react";
 
-import { Text } from "@react-three/drei";
 import { Color, useFrame, useThree } from "@react-three/fiber";
 import { type Mesh, Vector3 } from "three";
 import { getSatelliteName } from "tle.js";
+
+import { Text } from "@/components/space/text";
 
 import { useTime } from "@/hooks/time";
 

--- a/src/components/space/text.tsx
+++ b/src/components/space/text.tsx
@@ -1,0 +1,12 @@
+import type { ComponentProps } from "react";
+
+import { Text as DreiText } from "@react-three/drei";
+
+export type TextProps = Omit<ComponentProps<typeof DreiText>, "font">;
+
+export const Text = (props: TextProps) => (
+  <DreiText
+    font="https://fonts.gstatic.com/s/titilliumweb/v15/NaPecZTIAOhVxoMyOr9n_E7fRMc.woff"
+    {...props}
+  />
+);

--- a/src/components/space/trajectory.tsx
+++ b/src/components/space/trajectory.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useRef, useState } from "react";
 
-import { Text } from "@react-three/drei";
 import { Color, useFrame, useThree } from "@react-three/fiber";
 import { Mesh } from "three";
 import { getSatelliteName } from "tle.js";
+
+import { Text } from "@/components/space/text";
 
 import { useTime } from "@/hooks/time";
 


### PR DESCRIPTION
This pull request fixes [`Content-Security-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) directive violations (discovered in #9) when the `Scene` component is used in a different page by updating the `Content-Security-Policy` response header and adds a `Text` component wrapping [drei's `Text`](https://github.com/pmndrs/drei#text) that adds an appropriate [Google Fonts](https://fonts.google.com/) URL present in the [`connect-src`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src) directive.