### PR TITLE
chore: add `importsNotUsedAsValues` compiler option

### DIFF
--- a/src/components/icons/satellite.tsx
+++ b/src/components/icons/satellite.tsx
@@ -1,4 +1,4 @@
-import { SVGProps } from "react";
+import type { SVGProps } from "react";
 
 export type SatelliteIconProps = Omit<SVGProps<SVGSVGElement>, "viewBox">;
 

--- a/src/components/space/earth.tsx
+++ b/src/components/space/earth.tsx
@@ -2,7 +2,7 @@ import { useRef } from "react";
 
 import { useTexture } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
-import { type Mesh } from "three";
+import type { Mesh } from "three";
 
 import { IMAGES } from "@/constants/images";
 

--- a/src/components/space/trajectory.tsx
+++ b/src/components/space/trajectory.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 
 import { Color, useFrame, useThree } from "@react-three/fiber";
-import { Mesh } from "three";
+import type { Mesh } from "three";
 import { getSatelliteName } from "tle.js";
 
 import { Text } from "@/components/space/text";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "importsNotUsedAsValues": "error",
     "incremental": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
This pull requests configures [TypeScript's `importsNotUsedAsValues` compiler option](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) to ensure no values are being accidentally imported, when a value import is only used as a type.