### PR TITLE
chore: replace `@ts-check` with `checkJs`

### DIFF
--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 const { readdirSync } = require("fs");
 const { builtinModules } = require("module");
 const { resolve } = require("path");

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 /** @type {import("eslint").Linter.Config} */
 const eslintConfig = {
   extends: ["./.eslintrc.base.js", "next/core-web-vitals", "prettier"],

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,3 @@
-// @ts-check
-
 import bundleAnalyzer from "@next/bundle-analyzer";
 
 /**

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 /** @type {import("prettier").Options} */
 const prettierConfig = {
   arrowParens: "always",

--- a/src/environment/client.mjs
+++ b/src/environment/client.mjs
@@ -1,4 +1,3 @@
-// @ts-check
 import { clientEnv, clientSchema } from "./schema.mjs";
 
 const _clientEnv = clientSchema.safeParse(clientEnv);

--- a/src/environment/schema.mjs
+++ b/src/environment/schema.mjs
@@ -1,4 +1,3 @@
-// @ts-check
 import { z } from "zod";
 
 /**

--- a/src/environment/server.mjs
+++ b/src/environment/server.mjs
@@ -1,4 +1,3 @@
-// @ts-check
 /**
  * This file is included in `/next.config.mjs` which ensures the app isn't built with invalid env vars.
  * It has to be a `.mjs`-file to be imported there.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 const defaultTheme = require("tailwindcss/defaultTheme");
 
 /** @type {import("tailwindcss").Config} */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "baseUrl": ".",
+    "checkJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "importsNotUsedAsValues": "error",


### PR DESCRIPTION
This pull request removes [`@ts-check` comments](https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check) in JavaScript files in favor of [`checkJs` TypeScript compiler option](https://www.typescriptlang.org/tsconfig#checkJs) to avoid unnecessary repetition.